### PR TITLE
Correct the timestamp in interposer_log

### DIFF
--- a/tlsinterposer.c
+++ b/tlsinterposer.c
@@ -99,7 +99,7 @@ void interposer_log(const char *format, ...)
 	va_start(ap, format);
 	// Fall back to stderr on problems
 	fprintf(log, "%04d-%02d-%02d %02d:%02d:%02d tlsinterposer[%d]: ",
-		tm.tm_year, tm.tm_mon, tm.tm_mday, tm.tm_hour, tm.tm_min, tm.tm_sec, getpid());
+		1900 + tm.tm_year, 1 + tm.tm_mon, tm.tm_mday, tm.tm_hour, tm.tm_min, tm.tm_sec, getpid());
 	vfprintf(log, format, ap);
 	va_end(ap);
 	if (log != stderr) fclose(log);


### PR DESCRIPTION
tm_year is in years after 1900, and tm_mon is zero-based.

Tested on Linux.  Looking at the man page, this should apply to all standard systems, but you may want to double-check.
